### PR TITLE
Fix division by zero in alert generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -305,7 +305,7 @@ function renderTable(id, headers, rows){
 // Alerts
 function renderAlerts(){
   const rows = slice();
-  const lowMargin = rows.filter(r => (r.revenue - r.cost)/r.revenue < 0.1);
+  const lowMargin = rows.filter(r => r.revenue > 0 && (r.revenue - r.cost)/r.revenue < 0.1);
   const stockouts = state.inventory.filter(i=>i.status==='Stockout');
   const overdue = state.invoices.filter(i=>i.status==='Vencida');
   const items = [];


### PR DESCRIPTION
## Summary
- avoid dividing by zero when calculating low-margin alert statistics

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689b5bdb7d5c832e9e9c0c79d00d5149